### PR TITLE
allow components to inherit props

### DIFF
--- a/lib/components/slideshow/fade.js
+++ b/lib/components/slideshow/fade.js
@@ -18,6 +18,8 @@ var _tween = require('@tweenjs/tween.js');
 
 var TWEEN = _interopRequireWildcard(_tween);
 
+var _helpers = require('../../helpers.js');
+
 require('./fade.css');
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
@@ -143,9 +145,10 @@ var Fade = function (_Component) {
           children = _state2.children,
           index = _state2.index;
 
+      var unhandledProps = (0, _helpers.getUnhandledProps)(Fade.defaultProps, this.props);
       return _react2.default.createElement(
         'div',
-        null,
+        unhandledProps,
         _react2.default.createElement(
           'div',
           { className: 'react-slideshow-container' },

--- a/lib/components/slideshow/fade.js
+++ b/lib/components/slideshow/fade.js
@@ -145,7 +145,7 @@ var Fade = function (_Component) {
           children = _state2.children,
           index = _state2.index;
 
-      var unhandledProps = (0, _helpers.getUnhandledProps)(Fade.defaultProps, this.props);
+      var unhandledProps = (0, _helpers.getUnhandledProps)(Fade.propTypes, this.props);
       return _react2.default.createElement(
         'div',
         unhandledProps,

--- a/lib/components/slideshow/slide.js
+++ b/lib/components/slideshow/slide.js
@@ -135,7 +135,7 @@ var Slideshow = function (_Component) {
           indicators = _props2.indicators,
           arrows = _props2.arrows;
 
-      var unhandledProps = (0, _helpers.getUnhandledProps)(Slideshow.defaultProps, this.props);
+      var unhandledProps = (0, _helpers.getUnhandledProps)(Slideshow.propTypes, this.props);
       var index = this.state.index;
 
       var style = {

--- a/lib/components/slideshow/slide.js
+++ b/lib/components/slideshow/slide.js
@@ -18,6 +18,8 @@ var _propTypes = require('prop-types');
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
+var _helpers = require('../../helpers.js');
+
 require('./slide.css');
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
@@ -132,6 +134,8 @@ var Slideshow = function (_Component) {
           autoplay = _props2.autoplay,
           indicators = _props2.indicators,
           arrows = _props2.arrows;
+
+      var unhandledProps = (0, _helpers.getUnhandledProps)(Slideshow.defaultProps, this.props);
       var index = this.state.index;
 
       var style = {
@@ -144,7 +148,7 @@ var Slideshow = function (_Component) {
       }
       return _react2.default.createElement(
         'div',
-        null,
+        unhandledProps,
         _react2.default.createElement(
           'div',
           { className: 'react-slideshow-container' },

--- a/lib/components/slideshow/zoom.js
+++ b/lib/components/slideshow/zoom.js
@@ -145,7 +145,7 @@ var Zoom = function (_Component) {
           children = _state2.children,
           index = _state2.index;
 
-      var unhandledProps = (0, _helpers.getUnhandledProps)(Zoom.defaultProps, this.props);
+      var unhandledProps = (0, _helpers.getUnhandledProps)(Zoom.propTypes, this.props);
       return _react2.default.createElement(
         'div',
         unhandledProps,

--- a/lib/components/slideshow/zoom.js
+++ b/lib/components/slideshow/zoom.js
@@ -18,6 +18,8 @@ var _tween = require('@tweenjs/tween.js');
 
 var TWEEN = _interopRequireWildcard(_tween);
 
+var _helpers = require('../../helpers.js');
+
 require('./zoom.css');
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
@@ -143,9 +145,10 @@ var Zoom = function (_Component) {
           children = _state2.children,
           index = _state2.index;
 
+      var unhandledProps = (0, _helpers.getUnhandledProps)(Zoom.defaultProps, this.props);
       return _react2.default.createElement(
         'div',
-        null,
+        unhandledProps,
         _react2.default.createElement(
           'div',
           { className: 'react-slideshow-container' },

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,15 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+function getUnhandledProps(ComponentProps, props) {
+  var handledProps = Object.keys(ComponentProps);
+  return Object.keys(props).reduce(function (acc, prop) {
+    if (prop === 'childkey') return acc;
+    if (handledProps.indexOf(prop) === -1) acc[prop] = props[prop];
+    return acc;
+  }, {});
+}
+
+exports.getUnhandledProps = getUnhandledProps;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -6,7 +6,6 @@ Object.defineProperty(exports, "__esModule", {
 function getUnhandledProps(ComponentProps, props) {
   var handledProps = Object.keys(ComponentProps);
   return Object.keys(props).reduce(function (acc, prop) {
-    if (prop === 'childkey') return acc;
     if (handledProps.indexOf(prop) === -1) acc[prop] = props[prop];
     return acc;
   }, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slideshow-image",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -920,6 +920,70 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "babel-cli": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-polyfill": "^6.26.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "chokidar": "^1.6.1",
+        "commander": "^2.11.0",
+        "convert-source-map": "^1.5.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "glob": "^7.1.2",
+        "lodash": "^4.17.4",
+        "output-file-sync": "^1.1.2",
+        "path-is-absolute": "^1.0.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6",
+        "v8flags": "^2.1.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -1483,6 +1547,25 @@
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
       }
     },
     "babel-preset-es2015": {
@@ -4147,6 +4230,12 @@
           }
         }
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -8688,6 +8777,17 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.4",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.0"
+      }
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -12263,6 +12363,12 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
     "util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -12311,6 +12417,15 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
       "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
       "dev": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true,
+      "requires": {
+        "user-home": "^1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git+https://github.com/andela-foladeji/react-slideshow.git"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.3",
     "babel-preset-es2015": "^6.24.1",

--- a/src/lib/components/slideshow/fade.js
+++ b/src/lib/components/slideshow/fade.js
@@ -85,7 +85,7 @@ class Fade extends Component {
   render() {
     const { indicators, arrows, infinite } = this.props;
     const { children, index } = this.state;
-    const unhandledProps = getUnhandledProps(Fade.defaultProps, this.props);
+    const unhandledProps = getUnhandledProps(Fade.propTypes, this.props);
     return (
       <div {...unhandledProps}>
         <div className="react-slideshow-container">

--- a/src/lib/components/slideshow/fade.js
+++ b/src/lib/components/slideshow/fade.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as TWEEN from '@tweenjs/tween.js';
+import { getUnhandledProps } from '../../helpers.js';
 
 import './fade.css';
 
@@ -84,8 +85,9 @@ class Fade extends Component {
   render() {
     const { indicators, arrows, infinite } = this.props;
     const { children, index } = this.state;
+    const unhandledProps = getUnhandledProps(Fade.defaultProps, this.props);
     return (
-      <div>
+      <div {...unhandledProps}>
         <div className="react-slideshow-container">
           {arrows && (
             <div

--- a/src/lib/components/slideshow/slide.js
+++ b/src/lib/components/slideshow/slide.js
@@ -82,10 +82,7 @@ class Slideshow extends Component {
       indicators,
       arrows
     } = this.props;
-    const unhandledProps = getUnhandledProps(
-      Slideshow.defaultProps,
-      this.props
-    );
+    const unhandledProps = getUnhandledProps(Slideshow.propTypes, this.props);
     const { index } = this.state;
     const style = {
       transform: `translate(-${(index + 1) * this.width}px)`

--- a/src/lib/components/slideshow/slide.js
+++ b/src/lib/components/slideshow/slide.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import * as TWEEN from '@tweenjs/tween.js';
 import PropTypes from 'prop-types';
+import { getUnhandledProps } from '../../helpers.js';
 
 import './slide.css';
 
@@ -81,6 +82,10 @@ class Slideshow extends Component {
       indicators,
       arrows
     } = this.props;
+    const unhandledProps = getUnhandledProps(
+      Slideshow.defaultProps,
+      this.props
+    );
     const { index } = this.state;
     const style = {
       transform: `translate(-${(index + 1) * this.width}px)`
@@ -89,7 +94,7 @@ class Slideshow extends Component {
       this.timeout = setTimeout(() => this.preSlide('next'), duration);
     }
     return (
-      <div>
+      <div {...unhandledProps}>
         <div className="react-slideshow-container">
           {arrows && (
             <div

--- a/src/lib/components/slideshow/zoom.js
+++ b/src/lib/components/slideshow/zoom.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as TWEEN from '@tweenjs/tween.js';
+import { getUnhandledProps } from '../../helpers.js';
 
 import './zoom.css';
 
@@ -84,8 +85,9 @@ class Zoom extends Component {
   render() {
     const { indicators, arrows, infinite } = this.props;
     const { children, index } = this.state;
+    const unhandledProps = getUnhandledProps(Zoom.defaultProps, this.props);
     return (
-      <div>
+      <div {...unhandledProps}>
         <div className="react-slideshow-container">
           {arrows && (
             <div

--- a/src/lib/components/slideshow/zoom.js
+++ b/src/lib/components/slideshow/zoom.js
@@ -85,7 +85,7 @@ class Zoom extends Component {
   render() {
     const { indicators, arrows, infinite } = this.props;
     const { children, index } = this.state;
-    const unhandledProps = getUnhandledProps(Zoom.defaultProps, this.props);
+    const unhandledProps = getUnhandledProps(Zoom.propTypes, this.props);
     return (
       <div {...unhandledProps}>
         <div className="react-slideshow-container">

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,7 +1,6 @@
 function getUnhandledProps(ComponentProps, props) {
   const handledProps = Object.keys(ComponentProps);
   return Object.keys(props).reduce((acc, prop) => {
-    if (prop === 'childkey') return acc;
     if (handledProps.indexOf(prop) === -1) acc[prop] = props[prop];
     return acc;
   }, {});

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,0 +1,10 @@
+function getUnhandledProps(ComponentProps, props) {
+  const handledProps = Object.keys(ComponentProps);
+  return Object.keys(props).reduce((acc, prop) => {
+    if (prop === 'childkey') return acc;
+    if (handledProps.indexOf(prop) === -1) acc[prop] = props[prop];
+    return acc;
+  }, {});
+}
+
+export { getUnhandledProps };


### PR DESCRIPTION
This allows the outer div of each component to inherit the props set on the parent component (convenient for inheriting `style` of `className` props).

Sidenote: added babel-cli as a devDependency at it is required to run the pre-commit hook. Also shouldn't the top-level /lib folder be added to .gitignore?